### PR TITLE
Add conda environment to local environment installation documentation

### DIFF
--- a/docs/setup-local.md
+++ b/docs/setup-local.md
@@ -134,6 +134,8 @@ export PATH=~/spark-2.4.0-bin-hadoop2.7/bin:$PATH
 Ins
 ```bash
 cd defoe
+conda create -n defoe-env python=2.7
+conda activate defoe-env
 conda install -c anaconda --file requirements.txt 
 pip freeze | grep azure > azure.txt
 pip uninstall -y -r azure.txt


### PR DESCRIPTION
 Suggestion to add a conda environment with the correct Python version to the documentation.